### PR TITLE
PREFIX defaults to /usr/local but can be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PREFIX=/usr/local
+
 all:
 	gcc -Wall -Wextra -pedantic -o hdump hdump.c
 
@@ -5,10 +7,10 @@ debug:
 	gcc -Wall -Wextra -pedantic -DDEBUG -o hdump hdump.c
 
 install:
-	install -m 0755 hdump /usr/local/bin/hdump
+	install -m 0755 hdump $(PREFIX)/bin/hdump
 
 uninstall:
-	rm -f /usr/local/bin/hdump
+	rm -f $(PREFIX)/bin/hdump
 
 clean:
 	rm -f hdump


### PR DESCRIPTION
Allows for more flexible installs without editing the Makefile.

```shell
$ make -n install
install -m 0755 hdump /usr/local/bin/hdump
$ make -n install PREFIX=/opt
install -m 0755 hdump /opt/bin/hdump
$ make -n install PREFIX=/home/USER/.local
install -m 0755 hdump /home/USER/.local/bin/hdump
```